### PR TITLE
Works on balenaFin

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -18,3 +18,4 @@ data:
   supportedDeviceTypes:
     - "raspberrypi3"
     - "raspberrypi4-64"
+    - "fincm3"


### PR DESCRIPTION
The balenaFin is based on the CM3 and thus this will work on the Fin as well as the RPi3. 

Change-type: patch
Signed-off-by: Alex Bucknall <alexbucknall@balena.io>